### PR TITLE
refactor: clean up psudeocode and indentations

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,13 @@
 <img src="./assets/tables.png" alt="Home page view" width="50%">
 
 
-### Context
+## Context
 
 “Down the Rabbit Hole” was developed as a consultancy project, inspired by one team member’s vision and brought to life by a collaborative team of five. Over a two-week period, we transformed the initial idea into a fully functional web application.
 
 Each team member participated in all phases of the project, from ideation to development and presentation. Regular meetings facilitated discussions on progress and challenges, ensuring that everyone had a comprehensive understanding of the codebase and project architecture. This collaborative effort resulted in an engaging educational platform that explores animal ecosystems.
 
-### Tech
+## Tech
 
 BE 
 - Ruby on Rails, tested with RSpec, simplecov
@@ -29,7 +29,7 @@ FE
 - Built with React and tested with Cypress
 - Deployed with [Netlify](https://down-the-rabbit-hole.netlify.app/)
 
-### Installation
+## Installation
 
 1. Fork and clone this BE repo 
 [Down The Rabbit Hole BE repo](https://github.com/Down-the-Rabbit-Holes/down_the_rabbit_hole_BE)
@@ -47,10 +47,8 @@ FE
 8.  Enter `control + c` in your terminal to stop running the React app at any time
 9. To run Cypress tests, use `npx cypress open`
 
-## Usage
-<!-- This is where we will display the GIF (no more than 2 of functionality) -->
 
-### Contributors:
+## Contributors:
 
 Candice Cirbo - [linkedin](https://www.linkedin.com/in/candicecirbo/) - [gitHub](https://github.com/CCirbo) - ccirbots@gmail.com
 
@@ -62,7 +60,7 @@ Renee Messersmith - [linkedin](https://www.linkedin.com/in/reneemessersmith/) - 
 
 Stefan Bloom - [linkedin](https://www.linkedin.com/in/stefanjbloom/) - [gitHub](https://github.com/stefanjbloom) - 	stefanjbloom@gmail.com
 
-### Learning Goals
+## Learning Goals
 
 - **Project Ideation and Execution**: Develop a web application from a student-led idea, focusing on solving real-world problems.
 

--- a/spec/requests/api/v1/animals_request_spec.rb
+++ b/spec/requests/api/v1/animals_request_spec.rb
@@ -20,12 +20,11 @@ RSpec.describe "Animals", type: :request do
       selected_params = { action_type: "selected_animal", name: "rabbit" }
 
       get "/api/v1/animals", params: selected_params
-      # binding.pry
 
       expect(response).to be_successful
 
       selected_animal = JSON.parse(response.body, symbolize_names: true)[:data]
-      # binding.pry
+      
       expect(selected_animal[:attributes][:name]).to eq("rabbit")
     end
   end

--- a/spec/requests/api/v1/user_favorites_request_spec.rb
+++ b/spec/requests/api/v1/user_favorites_request_spec.rb
@@ -28,29 +28,29 @@ RSpec.describe "UserFavorites", type: :request do
     end
     
     it 'returns a list of favorited animals' do
-        UserFavorite.create!(user_id: @user.id, animal_id: @animal.id)
+      UserFavorite.create!(user_id: @user.id, animal_id: @animal.id)
 
-        get "/api/v1/users/#{@user.id}/user_favorites"
+      get "/api/v1/users/#{@user.id}/user_favorites"
 
-        expect(response).to be_successful
-        expect(response.status).to eq(200)
+      expect(response).to be_successful
+      expect(response.status).to eq(200)
 
-        parsed_body = JSON.parse(response.body)
+      parsed_body = JSON.parse(response.body)
 
-        expect(parsed_body).to be_an(Array)
-        expect(parsed_body.first["name"]).to eq("test")
-        expect(parsed_body.first["photo_url"]).to eq("www.pexels.com/photo/two-playful-coyotes-27067820/")
-        expect(parsed_body.first["prey"]).to eq("Rabbit, Mice, Deer")
-        expect(parsed_body.first["predators"]).to eq("Human, Bears, Wolves, Great horned owls, Bald Eagles")
-        expect(parsed_body.first["habitat"]).to eq("Forests, plains and deserts")
-        expect(parsed_body.first["fun_fact"]).to eq("Also known as the Prairie Wolf!")
-        expect(parsed_body.first["top_speed"]).to eq("40 miles per hour")
-        expect(parsed_body.first["life_span"]).to eq("10 - 15 years")
-        expect(parsed_body.first["weight"]).to eq("7kg - 21kg (15lbs - 46lbs)")
-        expect(parsed_body.first["diet"]).to eq("Carnivore")
-        expect(parsed_body.first["scientific_name"]).to eq("Canis latrans")
-        expect(parsed_body.first["id"]).to eq(@animal.id)
-    end
+      expect(parsed_body).to be_an(Array)
+      expect(parsed_body.first["name"]).to eq("test")
+      expect(parsed_body.first["photo_url"]).to eq("www.pexels.com/photo/two-playful-coyotes-27067820/")
+      expect(parsed_body.first["prey"]).to eq("Rabbit, Mice, Deer")
+      expect(parsed_body.first["predators"]).to eq("Human, Bears, Wolves, Great horned owls, Bald Eagles")
+      expect(parsed_body.first["habitat"]).to eq("Forests, plains and deserts")
+      expect(parsed_body.first["fun_fact"]).to eq("Also known as the Prairie Wolf!")
+      expect(parsed_body.first["top_speed"]).to eq("40 miles per hour")
+      expect(parsed_body.first["life_span"]).to eq("10 - 15 years")
+      expect(parsed_body.first["weight"]).to eq("7kg - 21kg (15lbs - 46lbs)")
+      expect(parsed_body.first["diet"]).to eq("Carnivore")
+      expect(parsed_body.first["scientific_name"]).to eq("Canis latrans")
+      expect(parsed_body.first["id"]).to eq(@animal.id)
+  end
   end
 
   describe "POST /create" do
@@ -92,6 +92,7 @@ RSpec.describe "UserFavorites", type: :request do
       expect(parsed_body["id"]).to eq(@animal.id)
 
       user_favorite = UserFavorite.find_by(user_id: @user.id, animal_id: @animal.id)
+      
       expect(user_favorite).to be_a(UserFavorite)
       expect(user_favorite.user_id).to eq(@user.id)
       expect(user_favorite.animal_id).to eq(@animal.id)
@@ -128,14 +129,12 @@ RSpec.describe "UserFavorites", type: :request do
         )
 
       @user_favorite = UserFavorite.create!(user_id: @user.id, animal_id: @animal.id)
-
     end
 
     it 'deletes a favorite' do
       expect(UserFavorite.count).to eq(1)
       delete "/api/v1/users/#{@user.id}/user_favorites/#{@animal.id}"
     
-      
       expect(UserFavorite.count).to eq(0)
       expect(response).to have_http_status(:ok)
 


### PR DESCRIPTION
This PR cleans up psuedo-code and indentation along with removing an unnecessary section in the readme.